### PR TITLE
Fix: Update Ethers.js CDN link in live.html

### DIFF
--- a/src/frontend/live.html
+++ b/src/frontend/live.html
@@ -527,7 +527,7 @@
   
   <!-- JavaScript Libraries -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://cdn.ethers.io/lib/ethers-5.2.umd.min.js" type="application/javascript"></script>
+  <script src="https://cdn.jsdelivr.net/npm/ethers@5.2.0/dist/ethers.umd.min.js" type="application/javascript"></script>
   <script>
     // Configuration
     const CONFIG = {


### PR DESCRIPTION
The previous CDN link (cdn.ethers.io) for ethers-5.2.umd.min.js was failing with a net::ERR_NAME_NOT_RESOLVED error.

This commit updates the script source to use a working CDN link from cdn.jsdelivr.net for ethers@5.2.0, which resolves the issue of the library not loading and the subsequent 'ethers is not defined' JavaScript error.