### PR TITLE
Fix: Remove cdn.ethers.io from Content Security Policy

### DIFF
--- a/src/frontend/live.html
+++ b/src/frontend/live.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://cdn.ethers.io; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https:; connect-src *; frame-src *; base-uri 'self'; form-action 'self'; child-src *;" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https:; connect-src *; frame-src *; base-uri 'self'; form-action 'self'; child-src *;" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
   <meta http-equiv="Pragma" content="no-cache" />


### PR DESCRIPTION
To further troubleshoot the persistent 'net::ERR_NAME_NOT_RESOLVED' error for 'ethers-5.2.umd.min.js', this commit removes `https://cdn.ethers.io` from the `script-src` directive in the Content Security Policy of `src/frontend/live.html`.

While the primary script tag for Ethers.js was already updated to a working CDN (cdn.jsdelivr.net), this change ensures that no residual policies could inadvertently trigger requests to the problematic cdn.ethers.io domain.